### PR TITLE
fixing include file

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,6 @@
 <div class="container-fluid">
   {{ content }}
 </div>
-{{ include js-includes.html }}
+{% include js-includes.html %}
 </body>
 </html>


### PR DESCRIPTION
Error on line 8 of default.html [brackets should be replaced with % symbol]
```Liquid Warning: Liquid syntax error (line 8): Expected end_of_string but found id in "{{ include js-includes.html }}" in /_layouts/default.html```